### PR TITLE
finding algorithms oop interface

### DIFF
--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -2,10 +2,10 @@
 """
 This module implements classes, called Finders, for detecting stars in an
 astronomical image. The general convention is that all Finders are subclasses
-of an abstract class called StarFinder and should be callable classes.
-Additionally, StarFinder defines two abstract methods, namely, find_stars and
-__call__. In general, find_stars implements an algorithm for detecting stars
-and __call__ invokes find_stars to return stars positions estimatives. 
+of an abstract class called StarFinderBase and should be callable classes.
+Additionally, StarFinderBase defines the method find_stars as abstract.
+In general, find_stars implements an algorithm for detecting stars
+and __call__ invokes find_stars to return stars positions estimates. 
 """
 
 from __future__ import (absolute_import, division, print_function,
@@ -45,7 +45,7 @@ def irafstarfind(data, threshold, fwhm, sigma_radius=1.5, minsep_fwhm=2.5,
     return finder(data)
 
 
-class StarFinder:
+class StarFinderBase(object):
     """
     Base abstract class for Finders.
     """
@@ -57,7 +57,7 @@ class StarFinder:
         pass
 
 
-class DAOStarFinder(StarFinder):
+class DAOStarFinder(StarFinderBase):
     """
     Detect stars in an image using the DAOFIND algorithm.
 
@@ -225,7 +225,7 @@ class DAOStarFinder(StarFinder):
         return tbl
 
 
-class IRAFStarFinder(StarFinder):
+class IRAFStarFinder(StarFinderBase):
     """
     Detect stars in an image using IRAF's "starfind" algorithm.
 

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -14,9 +14,6 @@ from astropy.stats import gaussian_fwhm_to_sigma
 from .core import _convolve_data, find_peaks
 
 
-__all__ = ['daofind', 'irafstarfind']
-
-
 class StarFinder(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __call__(self, data):
@@ -156,9 +153,6 @@ class DAOFind(StarFinder):
         self.exclude_border = exclude_border
 
     def __call__(self, data):
-        return self._daofind(self, data)
-
-    def _daofind(self, data):
         daofind_kernel = _FindObjKernel(self.fwhm, self.ratio, self.theta,
                                         self.sigma_radius)
         self.threshold *= daofind_kernel.relerr
@@ -303,9 +297,6 @@ class IRAFStarFind(StarFinder):
         self.exclude_border = exclude_border
 
     def __call__(self, data):
-        return self.irafstarfind(self, data)
-
-    def _irafstarfind(self, data):
         starfind_kernel = _FindObjKernel(self.fwhm, ratio=1.0, theta=0.0,
                                          sigma_radius=self.sigma_radius)
         min_separation = max(2, int((fwhm * minsep_fwhm) + 0.5))

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 import warnings
 import math
 import numpy as np
+import abc
 from astropy.table import Column, Table
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.stats import gaussian_fwhm_to_sigma
@@ -15,6 +16,13 @@ from .core import _convolve_data, find_peaks
 
 __all__ = ['daofind', 'irafstarfind']
 
+
+class StarFinder(metaclass=abc.ABCMeta):
+
+    @abc.abstractmethod
+    __call__(self, data):
+        """Find potential stars in the given data."""
+        pass
 
 def daofind(data, threshold, fwhm, ratio=1.0, theta=0.0, sigma_radius=1.5,
             sharplo=0.2, sharphi=1.0, roundlo=-1.0, roundhi=1.0, sky=0.0,

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
-from ..findstars import daofind, irafstarfind
+from ..findstars import DAOStarFinder, IRAFStarFinder
 from ...datasets import make_100gaussians_image
 
 try:
@@ -33,11 +33,12 @@ warnings.simplefilter('always', AstropyUserWarning)
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.skipif('not HAS_SKIMAGE')
-class TestDAOFind(object):
+class TestDAOStarFinder(object):
     @pytest.mark.parametrize(('threshold', 'fwhm'),
                              list(itertools.product(THRESHOLDS, FWHMS)))
     def test_daofind(self, threshold, fwhm):
-        t = daofind(DATA, threshold, fwhm, sigma_radius=1.5)
+        starfinder = DAOStarFinder(threshold, fwhm, sigma_radius=1.5)
+        t = starfinder(DATA)
         datafn = ('daofind_test_thresh{0:04.1f}_fwhm{1:04.1f}'
                   '.txt'.format(threshold, fwhm))
         datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
@@ -46,45 +47,52 @@ class TestDAOFind(object):
                         np.array(t_ref).astype(np.float))
 
     def test_daofind_include_border(self):
-        t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
-                    exclude_border=False)
+        starfinder = DAOStarFinder(threshold=10, fwhm=2, sigma_radius=1.5,
+                                   exclude_border=False)
+        t = starfinder(DATA)
         assert len(t) == 20
 
     def test_daofind_exclude_border(self):
-        t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
-                    exclude_border=True)
+        starfinder = DAOStarFinder(threshold=10, fwhm=2, sigma_radius=1.5,
+                                   exclude_border=True)
+        t = starfinder(DATA)
         assert len(t) == 19
 
     def test_daofind_nosources(self):
         data = np.ones((3, 3))
-        t = daofind(data, threshold=10, fwhm=1)
+        starfinder = DAOStarFinder(threshold=10, fwhm=1)
+        t = starfinder(data)
         assert len(t) == 0
 
     def test_daofind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        t = daofind(DATA, threshold=50, fwhm=1.0, sharplo=1.)
+        starfinder = DAOStarFinder(threshold=50, fwhm=1.0, sharplo=1.)
+        t = starfinder(DATA)
         assert len(t) == 0
 
     def test_daofind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        t = daofind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
+        starfinder = DAOStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
+        t = starfinder(DATA)
         assert len(t) == 0
 
     def test_daofind_flux_negative(self):
         """Test handling of negative flux (here created by large sky)."""
         data = np.ones((5, 5))
         data[2, 2] = 10.
-        t = daofind(data, threshold=0.1, fwhm=1.0, sky=10)
+        starfinder = DAOStarFinder(threshold=0.1, fwhm=1.0, sky=10)
+        t = starfinder(data)
         assert not np.isfinite(t['mag'])
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.skipif('not HAS_SKIMAGE')
-class TestIRAFStarFind(object):
+class TestIRAFStarFinder(object):
     @pytest.mark.parametrize(('threshold', 'fwhm'),
                              list(itertools.product(THRESHOLDS, FWHMS)))
     def test_irafstarfind(self, threshold, fwhm):
-        t = irafstarfind(DATA, threshold, fwhm, sigma_radius=1.5)
+        starfinder = IRAFStarFinder(threshold, fwhm, sigma_radius=1.5)
+        t = starfinder(DATA)
         datafn = ('irafstarfind_test_thresh{0:04.1f}_fwhm{1:04.1f}'
                   '.txt'.format(threshold, fwhm))
         datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
@@ -94,23 +102,28 @@ class TestIRAFStarFind(object):
 
     def test_irafstarfind_nosources(self):
         data = np.ones((3, 3))
-        t = irafstarfind(data, threshold=10, fwhm=1)
+        starfinder = IRAFStarFinder(threshold=10, fwhm=1)
+        t = starfinder(data) 
         assert len(t) == 0
 
     def test_irafstarfind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        t = irafstarfind(DATA, threshold=50, fwhm=1.0, sharplo=2.)
+        starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, sharplo=2.)
+        t = starfinder(DATA)
         assert len(t) == 0
 
     def test_irafstarfind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        t = irafstarfind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
+        starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
+        t = starfinder(DATA)
         assert len(t) == 0
 
     def test_irafstarfind_sky(self):
-        t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=10.)
+        starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=10.)
+        t = starfinder(DATA)
         assert len(t) == 4
 
     def test_irafstarfind_largesky(self):
-        t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=100.)
+        starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.)
+        t = starfinder(DATA)
         assert len(t) == 0


### PR DESCRIPTION
@eteq if that's the right idea, I'm going to change the tests so that they won't fail with this interface.
Also, see that most parameters do not have validators*, so I would add those too.
- Only fwhm, ratio, and sigma_radius are validated inside the _FindObjKernel class.
